### PR TITLE
maintenance update

### DIFF
--- a/data-raw/countries.R
+++ b/data-raw/countries.R
@@ -14,8 +14,7 @@ unhcr <-
 unsd <-
   request("https://unstats.un.org/unsd/methodology/m49/overview") |>
   req_perform() |>
-  resp_body_string() |>
-  read_html() |>
+  resp_body_html() |>
   html_table() |>
   pluck(1) |>
   select(iso_code = X12,

--- a/data-raw/countries.R
+++ b/data-raw/countries.R
@@ -1,33 +1,21 @@
 library(tidyverse)
+library(httr2)
 library(rvest)
 
-unhcr_by_region <-
-  jsonlite::fromJSON("https://api.unhcr.org/population/v1/regions")$items |>
-  transmute(unhcr_region = name,
-            data = map(id, \(x) jsonlite::fromJSON(glue::glue("https://api.unhcr.org/population/v1/countries?unhcr_region={x}"))$items)) |>
-  unnest(data)
-
-unhcr_no_region <-
-  anti_join(jsonlite::fromJSON(glue::glue("https://api.unhcr.org/population/v1/countries"))$items,
-            unhcr_by_region, by = "code")
-
-corrections <-
-  tribble(~code,  ~iso, ~name,                                          ~unhcr_region,
-          "SGS", "SGS", "South Georgia and the South Sandwich Islands", "Europe",
-          "TIB",    NA, "Tibetan",                                      "Asia and the Pacific",
-          # FIXME: the next two ISO codes are for machine-readable passports, not countries.
-          # Should we keep them? The first appears in the API but the second doesn't.
-          "STA", "XXA", "Stateless",                                    NA,
-          "UKN", "XXX", "Unknown",                                      NA)
-
 unhcr <-
-  bind_rows(unhcr_by_region, unhcr_no_region) |>
-  rows_update(corrections, by = "code") |>
-  select(iso_code = iso, unhcr_code = code, name, unhcr_region) |>
-  arrange(name)
+  request("https://www.unhcr.org/refugee-statistics/insights/data/Annex_Countries.csv") |>
+  req_headers(Referer = "https://www.unhcr.org/") |>
+  req_perform() |>
+  resp_body_string() |>
+  read_csv() |>
+  select(iso_code = ISO3_Country_Code, unhcr_code = UNHCR_Country_Code,
+         name = UNSD_Name, unhcr_region = UNHCR_Region_Name)
 
-m49 <-
-  session("https://unstats.un.org/unsd/methodology/m49/overview") |>
+unsd <-
+  request("https://unstats.un.org/unsd/methodology/m49/overview") |>
+  req_perform() |>
+  resp_body_string() |>
+  read_html() |>
   html_table() |>
   pluck(1) |>
   select(iso_code = X12,
@@ -35,6 +23,26 @@ m49 <-
          unsd_subregion = X6,
          unsd_imregion = X8)
 
-countries <- left_join(unhcr, m49)
+# Present in the population table but not the GT annexes
+tib <- tibble(unhcr_code = "TIB",
+              iso_code = "TIB",
+              name = "Tibetan",
+              unhcr_region = "Asia and the Pacific",
+              unsd_region = "Asia",
+              unsd_subregion = "Eastern Asia")
+
+# Country name spelled differently between annex and data tables
+cuw <- tibble(unhcr_code = "CUW",
+              name = "Curacao")
+
+# ISO code is recorded as "UNK" in data tables. "UKN" in the annexes.
+ukn <- tibble(unhcr_code = "UKN",
+              iso_code = "UNK")
+
+countries <-
+  left_join(unhcr, unsd) |>
+  rows_upsert(tib) |>
+  rows_upsert(cuw) |>
+  rows_upsert(ukn)
 
 usethis::use_data(countries, overwrite = TRUE)

--- a/data-raw/flows.R
+++ b/data-raw/flows.R
@@ -1,23 +1,12 @@
 library(tidyverse)
 library(readxl)
-library(curl)
-
+library(httr2)
 
 tmpf <- fs::file_temp(ext = "xlsx")
 
-h <- curl::new_handle()
-
-curl::handle_setheaders(
-  h,
-  "User-Agent"      = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/126.0 Safari/537.36 R/curl",
-  "Referer"         = "https://www.unhcr.org/refugee-statistics/",
-  "Accept"          = "text/html,application/xhtml+xml,application/xml;q=0.9,application/octet-stream,*/*;q=0.8",
-  "Accept-Language" = "en-US,en;q=0.9",
-  "Connection"      = "keep-alive"
-)
-
-
-curl::curl_download("https://www.unhcr.org/refugee-statistics/insights/data/UNHCR_Flow_Data.xlsx", tmpf, handle = h, mode = "wb")
+request("https://www.unhcr.org/refugee-statistics/insights/data/UNHCR_Flow_Data.xlsx") |>
+  req_headers(Referer = "https://www.unhcr.org/refugee-statistics/") |>
+  req_perform(path = tmpf)
 
 flows <-
   read_excel(tmpf, sheet = "DATA") |>

--- a/data-raw/rdf.R
+++ b/data-raw/rdf.R
@@ -1,33 +1,17 @@
 library(tidyverse)
+library(httr2)
 
 fetch_dataset <- function(dataset, ...) {
-  read_json <- insistently(jsonlite::fromJSON, rate = rate_delay(60))
-  results_per_page <- 10000
-
-  rdf_url <- function(dataset, ...) {
-    httr::modify_url("https://api.unhcr.org/",
-                     path = glue::glue("/population/v1/{dataset}"),
-                     query = rlang::list2(coo_all = "true",
-                                          coa_all = "true",
-                                          ...))
-  }
-
-  fetch_page <- function(page) {
-    rdf_url(dataset, limit = results_per_page, page = page, ...) |>
-      read_json() |>
-      pluck("items") |>
-      mutate(across(everything(), as.character))
-  }
-
-  pages <-
-    rdf_url(dataset, limit = 1, page = 1, ...) |>
-    read_json() |>
-    pluck("maxPages")
-
-  map(1:ceiling(pages/results_per_page),
-      fetch_page,
-      .progress = dataset) |>
-    list_rbind() |>
+  request("https://api.unhcr.org/") |>
+    req_url_path("population", "v1", dataset) |>
+    req_url_query(coo_all = "true", coa_all = "true", limit = 10000, ...) |>
+    req_retry(max_tries = 10,
+              backoff = \(resp) 60) |>
+    req_perform_iterative(max_reqs = Inf,
+                          next_req = iterate_with_offset(param_name = "page",
+                                                         resp_pages = \(resp) resp_body_json(resp)$maxPages)) |>
+    resps_data(\(resp) resp_body_json(resp, simplifyVector = T)$items |>
+                 mutate(across(everything(), as.character))) |>
     type_convert(na = "-") |>
     select(-coo_id, -coa_id) |>
     as_tibble()


### PR DESCRIPTION
Reworked the data preparation scripts using httr2 for clarity and ease of maintenance.

The main user-facing changes are in the countries table:

- Now reads from the web version of the GT annexes instead of the old snapshot. The new table has fewer records (223 countries vs. 232 in the past) because it omits countries that do not appear as a COO/COA in the data. This should have no impact on our users.
- Added an ISO code and the UNSD region and subregion for Tibetans. Previously, we only had the country name and UNHCR region in the table. For some reason, Tibetans appear as a COO in the data but there's no corresponding entry in the countries annex.
- Updated the spelling for Curacao to match how it appears in the data. Ideally, we'd want to update the data to use the official spelling "Curaçao", same as we do with Türkiye. This is a stopgap measure in the meantime to make sure users don't lose data when joining data tables with countries by name (a subtle bug that we often run into in the Americas...).
- Corrected the ISO code for Unknown and Stateless to match how they appear in the data (UNK and STA). In the past I had set them to XXX and XXA, respectively, because UKN/STA aren't valid ISO codes. Note that the ISO code for Unknown appears in the GT annex as UKN but UNK is used in the data.

See if it's worth keeping these corrections or fixing the underlying issues in the original data sources.